### PR TITLE
chore: parametrize for used pckg mgr (pnpm support)

### DIFF
--- a/ci/repipe
+++ b/ci/repipe
@@ -18,5 +18,5 @@ ytt -f ci > ${TMPDIR}/pipeline.yml
 
 echo "Updating pipeline @ ${target}"
 
-fly -t ${target} set-pipeline --team=${team} -p concourse-shared -c ${TMPDIR}/pipeline.yml
-fly -t ${target} unpause-pipeline --team=${team} -p concourse-shared
+fly -t ${target} set-pipeline --team=${team} -p blink-concourse-shared -c ${TMPDIR}/pipeline.yml
+fly -t ${target} unpause-pipeline --team=${team} -p blink-concourse-shared

--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -448,11 +448,17 @@ source:
   repository: #@ public_docker_registry() + "/" + data.values.gh_repository if publicRepo else private_docker_registry() + "/" + data.values.gh_repository
 #@ end
 
-#@ def nodejs_deps_resource(webhook = False):
+#@ def nodejs_deps_resource(webhook = False, pckgMgr = "yarn"):
 name: deps
 type: git
 source:
+#@ if pckgMgr == "yarn":
   paths: [yarn.lock]
+#@ elif pckgMgr == "npm":
+  paths: [pnpm-lock.yaml]
+#@ else:
+#@     assert.fail("unsupported package manager: " + pckgMgr)
+#@ end
   uri: #@ data.values.git_uri
   branch: #@ data.values.git_branch
   private_key: #@ data.values.github_private_key

--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -454,7 +454,7 @@ type: git
 source:
 #@ if pckgMgr == "yarn":
   paths: [yarn.lock]
-#@ elif pckgMgr == "npm":
+#@ elif pckgMgr == "pnpm":
   paths: [pnpm-lock.yaml]
 #@ else:
 #@     assert.fail("unsupported package manager: " + pckgMgr)

--- a/shared/ci/tasks/cache-pnpm-deps.sh
+++ b/shared/ci/tasks/cache-pnpm-deps.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+tar_out="$(pwd)/bundled-deps"
+
+pushd deps
+pnpm install
+git log --pretty=format:'%h' -n 1 > gitref
+
+tar -zcvf "${tar_out}/bundled-deps-v$(cat ../deps-version/number)-$(cat gitref).tgz" . > /dev/null
+
+popd

--- a/shared/ci/tasks/cache-pnpm-deps.sh
+++ b/shared/ci/tasks/cache-pnpm-deps.sh
@@ -6,25 +6,23 @@ tar_out="$(pwd)/bundled-deps"
 
 pushd deps
 # Install dependencies
-echo "  * pnpm install"
+echo "    --> pnpm install"
 pnpm install --shamefully-hoist
 
 # Get git reference for versioning
-echo "  * git log"
+echo "    --> git log"
 git log --pretty=format:'%h' -n 1 > gitref
 
 # Create the output filename
 output_file="${tar_out}/bundled-deps-v$(cat ../deps-version/number)-$(cat gitref).tgz"
 
 # Use --dereference to convert hard links to regular files
-echo "  * tar ..."
+echo "    --> tar ..."
 tar --dereference -zcf "$output_file" \
     --exclude='.git' \
     --exclude='.github' \
     --exclude='ci' \
     .
 
-echo "  * Contents:"
-tar -ztvf "$output_file"
-echo "  * Done!"
+echo "    --> Done!"
 popd

--- a/shared/ci/tasks/cache-pnpm-deps.sh
+++ b/shared/ci/tasks/cache-pnpm-deps.sh
@@ -5,9 +5,26 @@ set -eu
 tar_out="$(pwd)/bundled-deps"
 
 pushd deps
-pnpm install
+# Install dependencies
+echo "  * pnpm install"
+pnpm install --shamefully-hoist
+
+# Get git reference for versioning
+echo "  * git log"
 git log --pretty=format:'%h' -n 1 > gitref
 
-tar -zcvf "${tar_out}/bundled-deps-v$(cat ../deps-version/number)-$(cat gitref).tgz" . > /dev/null
+# Create the output filename
+output_file="${tar_out}/bundled-deps-v$(cat ../deps-version/number)-$(cat gitref).tgz"
 
+# Use --dereference to convert hard links to regular files
+echo "  * tar ..."
+tar --dereference -zcf "$output_file" \
+    --exclude='.git' \
+    --exclude='.github' \
+    --exclude='ci' \
+    .
+
+echo "  * Contents:"
+tar -ztvf "$output_file"
+echo "  * Done!"
 popd

--- a/shared/ci/tasks/nodejs-helpers.sh
+++ b/shared/ci/tasks/nodejs-helpers.sh
@@ -14,7 +14,7 @@ function unpack_deps() {
   REPO_PATH=${REPO_PATH:-repo}
 
   if [[ -f ${REPO_PATH}/yarn.lock ]]; then
-    echo "Unpacking nodejs deps... "
+    echo "Unpacking nodejs deps... (yarn)"
 
     pushd ${REPO_PATH} > /dev/null
 
@@ -29,7 +29,38 @@ function unpack_deps() {
     echo "Done!"
 
     popd
+  elif [[ -f ${REPO_PATH}/pnpm-lock.yaml ]]; then
+    echo "Unpacking nodejs deps... (pnpm)"
+
+    pushd ${REPO_PATH} > /dev/null
+
+    tar -zxvf ../bundled-deps/bundled-deps-*.tgz ./node_modules/ ./pnpm-lock.yaml ./.pnpm-store > /dev/null
+
+    if [[ "$(git status -s -uno)" != "" ]]; then
+      echo "Extracting deps has created a diff - deps are not in sync"
+      git --no-pager diff
+      exit 1;
+    fi
+
+    echo "Done!"
+    popd
   else
     echo "Skipping unpack deps"
+  fi
+}
+
+function check_code() {
+  if [[ -f ${REPO_PATH}/yarn.lock ]]; then
+    echo "Checking code... (yarn)"
+    yarn code:check
+    echo "Done!"
+  elif [[ -f ${REPO_PATH}/pnpm-lock.yaml ]]; then
+    echo "Checking code... (pnpm)"
+    pushd ${REPO_PATH} > /dev/null
+    pnpm code:check
+    echo "Done!"
+    popd
+  else 
+    echo "Skipping check code"
   fi
 }

--- a/shared/ci/tasks/nodejs-helpers.sh
+++ b/shared/ci/tasks/nodejs-helpers.sh
@@ -14,7 +14,7 @@ function unpack_deps() {
   REPO_PATH=${REPO_PATH:-repo}
 
   if [[ -f ${REPO_PATH}/yarn.lock ]]; then
-    echo "Unpacking nodejs deps... (yarn)"
+    echo "    --> Unpacking nodejs deps... (yarn)"
 
     pushd ${REPO_PATH} > /dev/null
 
@@ -26,11 +26,11 @@ function unpack_deps() {
       exit 1;
     fi
 
-    echo "Done!"
+    echo "    --> Done!"
 
     popd
   elif [[ -f ${REPO_PATH}/pnpm-lock.yaml ]]; then
-    echo "Unpacking nodejs deps... (pnpm)"
+    echo "    --> Unpacking nodejs deps... (pnpm)"
 
     pushd ${REPO_PATH} > /dev/null
 
@@ -42,10 +42,10 @@ function unpack_deps() {
       exit 1;
     fi
 
-    echo "Done!"
+    echo "    --> Done!"
     popd
   else
-    echo "Skipping unpack deps"
+    echo "    --> Skipping unpack deps"
   fi
 }
 
@@ -55,12 +55,12 @@ function check_code() {
     yarn code:check
     echo "Done!"
   elif [[ -f ${REPO_PATH}/pnpm-lock.yaml ]]; then
-    echo "Checking code... (pnpm)"
+    echo "    --> Checking code... (pnpm)"
     pushd ${REPO_PATH} > /dev/null
     pnpm code:check
-    echo "Done!"
+    echo "    --> Done!"
     popd
   else 
-    echo "Skipping check code"
+    echo "    --> Skipping check code"
   fi
 }


### PR DESCRIPTION
Some fragments are hardcoded for yarn. This PR parametrizes some of the jobs to either use yarn or pnpm.

This is to support https://github.com/blinkbitcoin/mavapay-client/pull/8