### PR TITLE
Chore: mavapay working

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -26,15 +26,15 @@ groups:
 #@ for repo in data.values.src_repos:
   - #@ "bump-shared-files-in-" + repo
 #@ end
-- name: images
-  jobs:
-  - build-rust-concourse-image
-  - build-nodejs-concourse-image
-  - build-wincross-pipeline-image
-  - build-release-pipeline-image
-- name: backups
-  jobs:
-  - backup-org-to-gcp
+#! - name: images
+#!   jobs:
+#!   - build-rust-concourse-image
+#!   - build-nodejs-concourse-image
+#!   - build-wincross-pipeline-image
+#!   - build-release-pipeline-image
+#! - name: backups
+#!   jobs:
+#!   - backup-org-to-gcp
 
 #@ def build_task(input_name, context_path):
 task: build
@@ -62,43 +62,43 @@ config:
 #@ end
 
 jobs:
-- name: build-rust-concourse-image
-  serial: true
-  plan:
-  - {get: rust-image-def, trigger: true}
-  - #@ build_task("rust-image-def", "rust-image-def/images/rust-concourse")
-  - put: rust-image
-    params:
-      image: image/image.tar
+#! - name: build-rust-concourse-image
+#!   serial: true
+#!   plan:
+#!   - {get: rust-image-def, trigger: true}
+#!   - #@ build_task("rust-image-def", "rust-image-def/images/rust-concourse")
+#!   - put: rust-image
+#!     params:
+#!       image: image/image.tar
 
-- name: build-nodejs-concourse-image
-  serial: true
-  plan:
-  - {get: nodejs-image-def, trigger: true}
-  - #@ build_task("nodejs-image-def", "nodejs-image-def/images/nodejs-concourse")
-  - put: nodejs-image
-    params:
-      image: image/image.tar
+#! - name: build-nodejs-concourse-image
+#!   serial: true
+#!   plan:
+#!   - {get: nodejs-image-def, trigger: true}
+#!   - #@ build_task("nodejs-image-def", "nodejs-image-def/images/nodejs-concourse")
+#!   - put: nodejs-image
+#!     params:
+#!       image: image/image.tar
 
-- name: build-release-pipeline-image
-  serial: true
-  plan:
-  - get: release-pipeline-image-def
-    trigger: true
-  - #@ build_task("release-pipeline-image-def", "release-pipeline-image-def/images/release")
-  - put: release-pipeline-image
-    params:
-      image: image/image.tar
+#! - name: build-release-pipeline-image
+#!   serial: true
+#!   plan:
+#!   - get: release-pipeline-image-def
+#!     trigger: true
+#!   - #@ build_task("release-pipeline-image-def", "release-pipeline-image-def/images/release")
+#!   - put: release-pipeline-image
+#!     params:
+#!       image: image/image.tar
 
-- name: build-wincross-pipeline-image
-  serial: true
-  plan:
-  - get: wincross-pipeline-image-def
-    trigger: true
-  - #@ build_task("wincross-pipeline-image-def", "wincross-pipeline-image-def/images/wincross")
-  - put: wincross-pipeline-image
-    params:
-      image: image/image.tar
+#! - name: build-wincross-pipeline-image
+#!   serial: true
+#!   plan:
+#!   - get: wincross-pipeline-image-def
+#!     trigger: true
+#!   - #@ build_task("wincross-pipeline-image-def", "wincross-pipeline-image-def/images/wincross")
+#!   - put: wincross-pipeline-image
+#!     params:
+#!       image: image/image.tar
 
 
 #@ for repo in data.values.src_repos:
@@ -145,27 +145,29 @@ jobs:
         path: pipeline-tasks/ci/tasks/open-pr.sh
 #@ end
 
-- name: backup-org-to-gcp
-  plan:
-  - in_parallel:
-    - { get: every-day-trigger, trigger: true }
-    - { get: pipeline-tasks }
-  - task: gcp-backup
-    config:
-      platform: linux
-      image_resource: 
-        type: registry-image
-        source:
-          repository: us.gcr.io/galoy-org/galoy-dev
-      inputs:
-      - name: pipeline-tasks
-      params:
-        GOOGLE_CREDENTIALS: #@ data.values.staging_inception_creds 
-        GOOGLE_BUCKET_NAME: #@ data.values.staging_bucket_name
-        GH_APP_ID: #@ data.values.github_app_id
-        GH_APP_PRIVATE_KEY: #@ data.values.github_app_private_key
-      run:
-        path: pipeline-tasks/ci/tasks/gcp-backup.sh
+#! This is failing in the galoy-org version of the pipeline. Not sure what it's doing so deactivating for now.
+
+#! - name: backup-org-to-gcp
+#!   plan:
+#!   - in_parallel:
+#!     - { get: every-day-trigger, trigger: true }
+#!     - { get: pipeline-tasks }
+#!   - task: gcp-backup
+#!     config:
+#!       platform: linux
+#!       image_resource: 
+#!         type: registry-image
+#!         source:
+#!           repository: us.gcr.io/galoy-org/galoy-dev
+#!       inputs:
+#!       - name: pipeline-tasks
+#!       params:
+#!         GOOGLE_CREDENTIALS: #@ data.values.staging_inception_creds 
+#!         GOOGLE_BUCKET_NAME: #@ data.values.staging_bucket_name
+#!         GH_APP_ID: #@ data.values.github_app_id
+#!         GH_APP_PRIVATE_KEY: #@ data.values.github_app_private_key
+#!       run:
+#!         path: pipeline-tasks/ci/tasks/gcp-backup.sh
 
 resources:
 - name: shared-files
@@ -206,72 +208,72 @@ resources:
     branch: #@ data.values.source_repo_branch
 #@ end
 
-- name: nodejs-image-def
-  type: git
-  source:
-    paths: [images/nodejs-concourse/Dockerfile]
-    uri: #@ data.values.git_uri
-    branch: #@ data.values.git_branch
-    private_key: #@ data.values.github_private_key
+#! - name: nodejs-image-def
+#!   type: git
+#!   source:
+#!     paths: [images/nodejs-concourse/Dockerfile]
+#!     uri: #@ data.values.git_uri
+#!     branch: #@ data.values.git_branch
+#!     private_key: #@ data.values.github_private_key
 
-- name: nodejs-image
-  type: registry-image
-  source:
-    tag: latest
-    username: #@ data.values.docker_registry_user
-    password: #@ data.values.docker_registry_password
-    repository: #@ data.values.docker_registry + "/nodejs-concourse"
+#! - name: nodejs-image
+#!   type: registry-image
+#!   source:
+#!     tag: latest
+#!     username: #@ data.values.docker_registry_user
+#!     password: #@ data.values.docker_registry_password
+#!     repository: #@ data.values.docker_registry + "/nodejs-concourse"
 
-- name: rust-image-def
-  type: git
-  source:
-    paths: [images/rust-concourse/Dockerfile]
-    uri: #@ data.values.git_uri
-    branch: #@ data.values.git_branch
-    private_key: #@ data.values.github_private_key
+#! - name: rust-image-def
+#!   type: git
+#!   source:
+#!     paths: [images/rust-concourse/Dockerfile]
+#!     uri: #@ data.values.git_uri
+#!     branch: #@ data.values.git_branch
+#!     private_key: #@ data.values.github_private_key
 
-- name: rust-image
-  type: registry-image
-  source:
-    tag: latest
-    username: #@ data.values.docker_registry_user
-    password: #@ data.values.docker_registry_password
-    repository: #@ data.values.docker_registry + "/rust-concourse"
+#! - name: rust-image
+#!   type: registry-image
+#!   source:
+#!     tag: latest
+#!     username: #@ data.values.docker_registry_user
+#!     password: #@ data.values.docker_registry_password
+#!     repository: #@ data.values.docker_registry + "/rust-concourse"
 
-- name: release-pipeline-image
-  type: registry-image
-  source:
-    tag: latest
-    username: #@ data.values.docker_registry_user
-    password: #@ data.values.docker_registry_password
-    repository: #@   data.values.docker_registry + "/release-pipeline"
+#! - name: release-pipeline-image
+#!   type: registry-image
+#!   source:
+#!     tag: latest
+#!     username: #@ data.values.docker_registry_user
+#!     password: #@ data.values.docker_registry_password
+#!     repository: #@   data.values.docker_registry + "/release-pipeline"
 
-- name: release-pipeline-image-def
-  type: git
-  source:
-    paths: [images/release/Dockerfile]
-    uri: #@ data.values.git_uri
-    branch: #@ data.values.git_branch
-    private_key: #@ data.values.github_private_key
+#! - name: release-pipeline-image-def
+#!   type: git
+#!   source:
+#!     paths: [images/release/Dockerfile]
+#!     uri: #@ data.values.git_uri
+#!     branch: #@ data.values.git_branch
+#!     private_key: #@ data.values.github_private_key
 
-- name: wincross-pipeline-image
-  type: registry-image
-  source:
-    tag: latest
-    username: #@ data.values.docker_registry_user
-    password: #@ data.values.docker_registry_password
-    repository: #@   data.values.docker_registry + "/wincross-rust"
+#! - name: wincross-pipeline-image
+#!   type: registry-image
+#!   source:
+#!     tag: latest
+#!     username: #@ data.values.docker_registry_user
+#!     password: #@ data.values.docker_registry_password
+#!     repository: #@   data.values.docker_registry + "/wincross-rust"
 
-- name: wincross-pipeline-image-def
-  type: git
-  source:
-    paths: [images/wincross/Dockerfile]
-    uri: #@ data.values.git_uri
-    branch: #@ data.values.git_branch
-    private_key: #@ data.values.github_private_key
+#! - name: wincross-pipeline-image-def
+#!   type: git
+#!   source:
+#!     paths: [images/wincross/Dockerfile]
+#!     uri: #@ data.values.git_uri
+#!     branch: #@ data.values.git_branch
+#!     private_key: #@ data.values.github_private_key
 
-- name: every-day-trigger
-  type: time
-  icon: clock-outline
-  source:
-    interval: 24h
+#! - name: every-day-trigger
+#!   type: time
+#!   icon: clock-outline
+#!   source:
+#!     interval: 24h

--- a/ci/tasks/open-pr.sh
+++ b/ci/tasks/open-pr.sh
@@ -18,4 +18,4 @@ gh pr create \
   --body-file ../body.md \
   --base ${BRANCH} \
   --head ${PR_BRANCH} \
-  --label galoybot
+  --label blinkbitcoinbot

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -2,11 +2,11 @@
 ---
 
 git_uri: git@github.com:blinkbitcoin/concourse-shared.git
-git_branch: main
+git_branch: kn/mavapay_working
 github_private_key: ((github-blinkbitcoin.private_key))
 github_token: ((github-blinkbitcoin.api_token))
 github_app_id: ((github-blinkbitcoin.github_app_id))
-github_app_private_key: ((github-blinkbitcoinb.github_app_private_key))
+github_app_private_key: ((github-blinkbitcoin.github_app_private_key))
 
 docker_registry: us.gcr.io/galoy-org
 docker_registry_user: ((docker-creds.username))
@@ -20,16 +20,4 @@ pr_branch: bump-shared-tasks
 source_repo_branch: main
 
 src_repos:
-  galoy: ["nodejs", "docker", "chart"]
-  stablesats-rs: ["rust", "docker", "chart"]
-  proof-of-sats: ["nodejs", "docker", "chart"]
-  galoy-cli: ["rust"]
-  sqlxmq-executor: ["rust", "docker"]
-  bria: ["rust", "docker", "chart"]
-  cala: ["rust", "docker"]
-  cala-enterprise: ["rust", "docker"]
-  lana-bank: ["rust", "docker"]
-  galoy-mobile: ["nodejs"]
-  blink-circles: ["nodejs", "docker", "chart"]
-  blink-fiat: ["nodejs", "docker", "chart"]
-  blink-kyc: ["nodejs", "docker", "chart"]
+  mavapay-clinet: ["nodejs"]

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -20,4 +20,4 @@ pr_branch: bump-shared-tasks
 source_repo_branch: main
 
 src_repos:
-  mavapay-clinet: ["nodejs"]
+  mavapay-client: ["nodejs"]

--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -1,5 +1,5 @@
 #@ load("@ytt:data", "data")
-
+#@ load("@ytt:assert", "assert")
 #@ def public_docker_registry():
 #@  return "us.gcr.io/galoy-org"
 #@ end

--- a/shared/ci/tasks/cache-pnpm-deps.sh
+++ b/shared/ci/tasks/cache-pnpm-deps.sh
@@ -7,7 +7,7 @@ tar_out="$(pwd)/bundled-deps"
 pushd deps
 # Install dependencies
 echo "    --> pnpm install"
-pnpm install --shamefully-hoist
+pnpm install --no-store # --shamefully-hoist
 
 # Get git reference for versioning
 echo "    --> git log"
@@ -18,7 +18,7 @@ output_file="${tar_out}/bundled-deps-v$(cat ../deps-version/number)-$(cat gitref
 
 # Use --dereference to convert hard links to regular files
 echo "    --> tar ..."
-tar --dereference -zcf "$output_file" \
+tar -zcf "$output_file" \
     --exclude='.git' \
     --exclude='.github' \
     --exclude='ci' \

--- a/shared/ci/tasks/nodejs-audit.sh
+++ b/shared/ci/tasks/nodejs-audit.sh
@@ -11,7 +11,15 @@ LEVEL=${LEVEL:-high}
 pushd ${REPO_ROOT}
 
 set +e
-yarn audit --groups dependencies --level ${LEVEL}
+if [[ -f ./yarn.lock ]]; then
+  yarn audit --groups dependencies --level ${LEVEL}
+elif [[ -f ./pnpm-lock.yaml ]]; then
+  pnpm audit --prod --audit-level=${LEVEL}
+else 
+  echo "Failed audit: Unsupported PckgMgr"
+  exit 2
+fi
+
 audit_return=$?
 set -e
 

--- a/shared/ci/tasks/nodejs-helpers.sh
+++ b/shared/ci/tasks/nodejs-helpers.sh
@@ -34,7 +34,7 @@ function unpack_deps() {
 
     pushd ${REPO_PATH} > /dev/null
 
-    tar -zxvf ../bundled-deps/bundled-deps-*.tgz ./node_modules/ ./pnpm-lock.yaml ./.pnpm-store > /dev/null
+    tar -zxvf ../bundled-deps/bundled-deps-*.tgz ./node_modules/ ./pnpm-lock.yaml > /dev/null
 
     if [[ "$(git status -s -uno)" != "" ]]; then
       echo "Extracting deps has created a diff - deps are not in sync"

--- a/shared/ci/tasks/nodejs-update-package-json.sh
+++ b/shared/ci/tasks/nodejs-update-package-json.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+# ----------- UPDATE REPO -----------
+git config --global user.email "bot@galoy.io"
+git config --global user.name "CI Bot"
+
+pushd repo
+
+jq --arg v "$(cat ../version/version)" '.version = $v' package.json > ../tmp && mv ../tmp package.json
+
+git add package.json
+git status
+
+if [[ "$(git status -s -uno)" != ""  ]]; then
+  git commit -m "ci(release): release version $(cat ../version/version)"
+fi


### PR DESCRIPTION
This is the first "payload-PR" for blinkbitcoin`s concourse-shared repo. It's a fork og galoy's concourse-shared repo and it needs to avoid unwanted interdependences. The ORIGINAL repo solves those purposes:
* It [builds](https://ci.blink.sv/teams/dev/pipelines/concourse-shared?group=images) a couple of images  for specific ci-related usecases (rust/nodejs/releasing and win-cross compiling)
* It creates a backup of all the repos (currently broken)
* It updates it's dependendent repos via PRs

So forking that repo is easy but getting it to work is not trivial. So, this PR:
* focuses on the necessity of the mavapay pipeline and therefore ...
* ... deactivates the first two use-cases 
* it also deactivates updates to all the repos the original repo does. That makes it possible that we can a bit more bold with changes

ToDo:

- [ ] Maybe get the backup working again for the blinkbitcoin-repos
- [ ] Remove the [massaging](https://github.com/blinkbitcoin/concourse-shared/blob/main/ci/tasks/bump-shared-files.sh#L26-L42) of the repos after the `vendir sync` which is counterintuitive and makes understanding and a workflow much more difficult
- [ ] include galoy-client to the repos to update