### PR TITLE
chore: Add blink-client and blink-nostr to be maintained

### DIFF
--- a/ci/values.yml
+++ b/ci/values.yml
@@ -21,4 +21,5 @@ source_repo_branch: main
 
 src_repos:
   mavapay-client: ["nodejs"]
-  blink-nostr: ["nodejs"]
+  blink-client: ["nodejs"]
+  blink-nostr: ["nodejs","docker","chart"]


### PR DESCRIPTION
This will take both repos into account for managing changes regarding the CI.

* blink-client might be a bit too early as the PR to migrate to pnpm is not yet merged but we can simply reject the PR bot-created-PR anyway.
* blink-nostr is still on yarn but the changes from concourse-shared is a great way to start migrating to pnpm.