### PR TITLE
fix: bumping for forked repos (and typo)

### DIFF
--- a/ci/tasks/open-pr.sh
+++ b/ci/tasks/open-pr.sh
@@ -6,16 +6,24 @@ export GH_TOKEN="$(ghtoken generate -b "${GH_APP_PRIVATE_KEY}" -i "${GH_APP_ID}"
 
 pushd source-repo
 
+# For forked repos (many are forked from galoy-money) we need to explicitely specify the repo-name below
+# So let's calculate here
+
+REPO_NAME=$(basename $(git config --get remote.origin.url) .git)
+REPO_OWNER=$(git config --get remote.origin.url | sed -n 's/.*github.com[:/]\([^/]*\).*/\1/p')
+FULL_REPO="${REPO_OWNER}/${REPO_NAME}"
+
 cat <<EOF >> ../body.md
 # Bump Shared Tasks
 
 This PR syncs in this repository, shared CI tasks from [concourse-shared](https://github.com/blinkbitcoin/concourse-shared).
 EOF
 
-gh pr close ${PR_BRANCH} || true
+gh pr close ${PR_BRANCH} --repo=${FULL_REPO} || true
 gh pr create \
   --title "ci(shared): bump vendored ci files" \
   --body-file ../body.md \
   --base ${BRANCH} \
   --head ${PR_BRANCH} \
-  --label blinkbitcoinbot
+  --label blinkbitcoinbot \
+  --repo=${FULL_REPO}

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -21,3 +21,4 @@ source_repo_branch: main
 
 src_repos:
   mavapay-client: ["nodejs"]
+  blink-nostr: ["nodejs"]

--- a/shared/ci/tasks/nodejs-helpers.sh
+++ b/shared/ci/tasks/nodejs-helpers.sh
@@ -4,7 +4,7 @@
 #! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 if [[ -z $(git config --global user.email) ]]; then
-  git config --global user.email "202112752+blinkbitcoinbot@users.noreply.github.com
+  git config --global user.email "202112752+blinkbitcoinbot@users.noreply.github.com"
 fi
 if [[ -z $(git config --global user.name) ]]; then
   git config --global user.name "CI blinkbitcoinbot"


### PR DESCRIPTION
For forked repos (many are forked from galoy-money) we need to explicitely specify the repo-name as gh would fail otherwise not knowing where the PR should go:

```
X No default remote repository has been set for this directory.

please run `gh repo set-default` to select a default remote repository.
X No default remote repository has been set for this directory.

please run `gh repo set-default` to select a default remote repository.

```
