### PR TITLE
chore: upgrade npm via recent docker-repo and more verbosity

### DIFF
--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -576,5 +576,5 @@ source:
 name: npm
 type: docker-image
 source:
-  repository: timotto/concourse-npm-resource
+  repository: k9ert/concourse-npm-resource
 #@ end

--- a/shared/ci/tasks/nodejs-update-package-json.sh
+++ b/shared/ci/tasks/nodejs-update-package-json.sh
@@ -8,11 +8,20 @@ git config --global user.name "CI blinkbitcoinbot"
 
 pushd repo
 
+echo "  --> Updating package.json with new version"
+
 jq --arg v "$(cat ../version/version)" '.version = $v' package.json > ../tmp && mv ../tmp package.json
 
+echo -n "  --> new version in package.json: "
+cat package.json | jq .version
+
+
 git add package.json
+
+echo "  --> git status:"
 git status
 
 if [[ "$(git status -s -uno)" != ""  ]]; then
+  echo "  --> committing"
   git commit -m "ci(release): release version $(cat ../version/version)"
 fi

--- a/shared/ci/tasks/prep-release-src.sh
+++ b/shared/ci/tasks/prep-release-src.sh
@@ -11,6 +11,7 @@ pushd repo
 
 # First time
 if [[ $(cat ../version/version) == "0.0.0" ]]; then
+  echo "  --> creating changelog for all commits"
   git cliff --config ../pipeline-tasks/ci/vendor/config/git-cliff.toml > ../artifacts/gh-release-notes.md
 
 # Fetch changelog from last ref
@@ -19,8 +20,8 @@ else
   export prev_ref
   new_ref=$(git rev-parse HEAD)
   export new_ref
-
-  git cliff --config ../pipeline-tasks/ci/vendor/config/git-cliff.toml "$prev_ref..$new_ref" > ../artifacts/gh-release-notes.md
+  echo "  --> creating changelog for $prev_ref..$new_ref"
+  git cliff --config ../pipeline-tasks/ci/vendor/config/git-cliff.toml $prev_ref..$new_ref > ../artifacts/gh-release-notes.md
 fi
 
 popd


### PR DESCRIPTION
The old timotto/concourse-npm-resource docker repo is 7 years old (as is the github repo). The npm-version has not been pinned and resulted in 8.1.4 back at the time.
This version does not seem to respect the .npmignore the way i'd like to see it.

So just by forking that repository (here: https://github.com/k9ert/concourse-npm-resource/blob/master/Dockerfile), building the image and pushing it to my [personal public docker repository](https://hub.docker.com/r/k9ert/concourse-npm-resource), i upgraded npm to version 10.9.2. The forking is obviously not strictly necessary but did it for good practices.