### PR TITLE
fix: docker-prep - Add newline for existing .env file without one

### DIFF
--- a/shared/ci/tasks/docker-prep-docker-build-env.sh
+++ b/shared/ci/tasks/docker-prep-docker-build-env.sh
@@ -4,7 +4,7 @@
 #! Don't change this file, instead change it in github.com/blinkbitcoin/concourse-shared
 
 if [[ -f version/version ]]; then
-  echo "VERSION=$(cat version/version)" >> repo/.env
+  echo -e "\nVERSION=$(cat version/version)" >> repo/.env
 fi
 
 echo "COMMITHASH=$(cat repo/.git/ref)" >> repo/.env


### PR DESCRIPTION
If a project has already an .env file without a newline at the end, not adding a newline will screw the .env file.