### PR TITLE
feat: wire up PARAMS_KEYS in run_on_nix_host ytt function

### DIFF
--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -200,6 +200,7 @@ on_failure: #@ slack_failure_notification()
 #@ params["SSH_PRIVATE_KEY"] = "((staging-ssh.ssh_private_key))"
 #@ params["SSH_PUB_KEY"] = "((staging-ssh.ssh_public_key))"
 #@ params["CMD"] = cmd
+#@ params["PARAMS_KEYS"] = " ".join(additional_params.keys())
 name: #@ name
 serial: true
 plan:


### PR DESCRIPTION
## Summary

- Add `PARAMS_KEYS` to the `run_on_nix_host` ytt function so `additional_params` keys are exported as environment variables on the remote nix host via SSH
- The `run-on-nix-host.sh` script already has `PARAMS_KEYS` handling (iterates keys, uses bash indirect expansion to export values) — this change wires up the ytt function to populate it
- Safe for all existing callers: when `additional_params` is empty (the default), `PARAMS_KEYS=""` and the shell export loop is skipped entirely

## Context

blink-card needs to pass `RAIN_API_KEY` (a Concourse vault secret) through to `tilt ci` on the nix host for e2e tests. Without `PARAMS_KEYS`, `additional_params` values exist in the Concourse task container but don't propagate through SSH.
Related PR: https://github.com/blinkbitcoin/blink-card/pull/99

## Test plan

- [x] Verified `" ".join({}.keys())` produces `""` — no-op for existing callers without additional_params
- [x] Verified `run-on-nix-host.sh` already handles `PARAMS_KEYS` export loop
- [x] Tested locally with blink-card e2e pipeline: `RAIN_API_KEY` propagates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)