### PR TITLE
fix(audit): replace archived actions-rs/audit-check with rustsec fork

### DIFF
--- a/shared/actions/rust-audit.yml
+++ b/shared/actions/rust-audit.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/audit-check@v1
+      # rustsec/audit-check is the maintained fork of the archived
+      # actions-rs/audit-check; it runs current cargo-audit against a
+      # freshly-pulled advisory-db, matching the Concourse `cargo audit` job.
+      - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
The synced Rust audit workflow (`shared/actions/rust-audit.yml`) uses **`actions-rs/audit-check@v1`**. The `actions-rs` org was **archived in 2021** — the action bundles a pinned, stale `cargo-audit` + advisory database, so it silently misses newly-published advisories.

This drifted from the **Concourse** `cargo audit` job (`make audit-code`), which pulls the latest RustSec advisory-db at run time. Concrete recent example in `blink-card`: the postgres DoS advisories published **2026-06-12** (RUSTSEC-2026-0178 / -0179 / -0180) **passed** the GitHub "Audit" check but **failed** Concourse — false-green on GitHub.

## Change
Swap to the maintained fork **`rustsec/audit-check@v2`**. It's a drop-in replacement (same `token:` input) that runs current `cargo-audit` against a freshly-pulled advisory-db, so the GitHub check and the Concourse job audit against the same data.

```diff
-      - uses: actions-rs/audit-check@v1
+      - uses: rustsec/audit-check@v2
```

## Blast radius
This file auto-syncs into every Rust repo's `.github/workflows/audit.yml` (+ `vendor/rust-audit.yml`), so all of them pick up the maintained action on next sync. Behaviour is unchanged except that fresh advisories are now actually caught.

## Follow-up (not in this PR)
`actions/checkout@v3` here (and in the other shared workflows: `check-code.yml`, `spelling.yml`) runs on the deprecated Node 16 runtime and should be bumped to `@v4` repo-wide — left out to keep this PR scoped to the audit drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)