### PR TITLE
chore: register symphony CI

### DIFF
--- a/ci/values.yml
+++ b/ci/values.yml
@@ -28,5 +28,6 @@ src_repos:
   blink-card: ["rust", "docker", "chart"]
   blink-lnurl-server: ["rust", "docker", "chart"]
   stablesats-rs: ["rust", "docker", "chart"]
+  symphony: ["rust", "docker", "chart"]
   blink-admin-panel-private: ["nodejs", "docker", "chart"]
   blink-terminal: ["nodejs", "docker", "chart"]


### PR DESCRIPTION
Register Symphony for shared Rust CI tasks